### PR TITLE
Fix for newer gnome versions

### DIFF
--- a/taildrop.py
+++ b/taildrop.py
@@ -80,7 +80,7 @@ class TaildropMenuProvider(GObject.GObject, Nautilus.MenuProvider):
             filename = unquote(file.get_uri()[7:])
             Taildrop.send_file(filename, hostname)
 
-    def get_file_items(self, _window, files):
+    def get_file_items(self, files):
         """
         Right click context menu for a batch of files.
         """
@@ -112,7 +112,7 @@ class TaildropMenuProvider(GObject.GObject, Nautilus.MenuProvider):
 
         return (top_menuitem,)
 
-    def get_background_items(self, window, file):
+    def get_background_items(self, file):
         """
         Adds the context menu to a folder.
         """


### PR DESCRIPTION
On newer gnome (python-nautilus?) versions, this plugin fails to load, throwing errors. 
> TypeError: TaildropMenuProvider.get_file_items() missing 1 required positional argument: 'files'
TypeError: TaildropMenuProvider.get_background_items() missing 1 required positional argument: 'file'


This PR fixes that, with the method pointed out here https://github.com/nextcloud/desktop/issues/5041#issuecomment-1287810023.