### PR TITLE
Add filter to hide funnel nodes from send menu

### DIFF
--- a/taildrop.py
+++ b/taildrop.py
@@ -30,6 +30,9 @@ class Taildrop:
         status = json.loads(process.stdout)
         items = []
         for _host, data in status['Peer'].items():
+            if data['HostName'] == "funnel-ingress-node":
+                continue
+
             items.append({
                 'hostname': data['HostName'],
                 'os': data['OS'],


### PR DESCRIPTION
If you have the funnels feature activated, there are a few (>8) funnels shown in the send menu. This PR adds a filter to hide these funnels from the menu.