### PR TITLE
Personal Device Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ What I do on my Ubuntu box, might vary between distribution:
 ```
 sudo apt update
 sudo apt install python3-nautilus
-mdkir -p ~/.local/share/nautilus-python/extensions/
+mkdir -p ~/.local/share/nautilus-python/extensions/
 cp taildrop.py ~/.local/share/nautilus-python/extensions/
 ```
 

--- a/taildrop.py
+++ b/taildrop.py
@@ -28,8 +28,11 @@ class Taildrop:
             check=False
         )
         status = json.loads(process.stdout)
+        user_id = status['Self']['UserID']
         items = []
         for _host, data in status['Peer'].items():
+            if data['UserID'] != user_id:
+                continue
             if data['HostName'] == "funnel-ingress-node":
                 continue
 


### PR DESCRIPTION
Taildrop currently only allows to send files between personal devices:

> Taildrop is currently limited to sending files between your own personal devices. You cannot send files to devices owned by other users (even users on the same Tailscale network).

from https://tailscale.com/kb/1106/taildrop.

I added a filter to only show devices owned by the same user id.